### PR TITLE
Drupal 8 should use ubuntu1404. D7 is already using it.

### DIFF
--- a/generators/app/templates/8/_example.config.yml
+++ b/generators/app/templates/8/_example.config.yml
@@ -1,7 +1,7 @@
 ---
 # `vagrant_box` can also be set to geerlingguy/centos6, geerlingguy/centos7,
 # geerlingguy/ubuntu1204, parallels/ubuntu-14.04, etc.
-vagrant_box: geerlingguy/ubuntu1604
+vagrant_box: geerlingguy/ubuntu1404
 vagrant_user: vagrant
 vagrant_synced_folder_default_type: nfs
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-mdsk",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Manati Drupal Starter Kit Generator",
   "homepage": "https://github.com/ManatiCR/",
   "author": {


### PR DESCRIPTION
See: 
https://github.com/arknoll/ansible-role-selenium/issues/20